### PR TITLE
Added example with labels to create plane tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - master
 
 before_install:
-  - mkdir $GOPATH/bin
+  - mkdir -p $GOPATH/bin
 
 install:
   - go get github.com/stretchr/testify/assert

--- a/controller/pods/controller_test.go
+++ b/controller/pods/controller_test.go
@@ -15,6 +15,7 @@ func TestPodInfoMethods(t *testing.T) {
 	var annotations = make(map[string]string)
 
 	labels["app"] = "kubernetes"
+	labels["production"] = "tag"
 	annotations["consul.register/enabled"] = "true"
 	annotations["consul.register/service.name"] = "servicename"
 
@@ -55,6 +56,7 @@ func TestPodInfoMethods(t *testing.T) {
 	assert.Error(t, err, "An error was expected")
 	assert.Equal(t, "podname-containername", service.ID)
 	assert.Contains(t, service.Tags, "kubernetes")
+	assert.Contains(t, service.Tags, "production")
 
 	isEnabledByAnnotation := podInfo.isRegisterEnabled()
 	assert.Equal(t, true, isEnabledByAnnotation)

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         run: nginx
+        production: tag # Would create `production` tag for service `nginx`. Instead of `production:tag`.
       annotations:
         consul.register/enabled: "true"
         #consul.register/service.name: "mynginx"


### PR DESCRIPTION
By default labels to consul tags use key value.
There are no information how to create tags with one word only.
Updated example how to create tags without value and updated tests.