### PR TITLE
fix example for registering only key from labels

### DIFF
--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         run: nginx
-        production: tag # Would create `production` tag for service `nginx`. Instead of `production:tag`.
+        production: "tag" # Would create `production` tag for service `nginx`. Instead of `production:tag`.
       annotations:
         consul.register/enabled: "true"
         #consul.register/service.name: "mynginx"


### PR DESCRIPTION
In current example service would be registering with key-value pair tag.
Correct is `production: "tag"`

```
func (p *PodInfo) labelsToTags(containerName string) []string {
	var tags []string
	tags = append(tags, fmt.Sprintf("pod:%s", p.Name))
	tags = append(tags, fmt.Sprintf("node:%s", p.NodeName))
	tags = append(tags, fmt.Sprintf("container:%s", containerName))

	for key, value := range p.Labels {
		// if value is equal to "tag" then set only key as tag
		if value == "tag" {
			tags = append(tags, key)
		} else {
			tags = append(tags, fmt.Sprintf("%s:%s", key, value))
		}
	}
	return tags
}
```
https://github.com/tczekajlo/kube-consul-register/blob/master/controller/pods/controller.go#L521