### PR TITLE
fix deprecated uses of Core()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ var config = &Config{}
 func Load(clientset *kubernetes.Clientset, namespace string, name string) (*Config, error) {
 	var filledConfig *Config
 
-	cfg, err := clientset.Core().ConfigMaps(namespace).Get(name)
+	cfg, err := clientset.CoreV1().ConfigMaps(namespace).Get(name)
 	if err != nil {
 		return config, fmt.Errorf(err.Error())
 	}

--- a/controller/endpoints/controller.go
+++ b/controller/endpoints/controller.go
@@ -63,7 +63,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 		consulAgents[c.cfg.Controller.ConsulAddress] = consulAgent
 
 	} else if c.cfg.Controller.RegisterMode == config.RegisterNodeMode {
-		nodes, err := c.clientset.Core().Nodes().List(v1.ListOptions{
+		nodes, err := c.clientset.CoreV1().Nodes().List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.ConsulNodeSelector,
 		})
 		if err != nil {
@@ -76,7 +76,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 			consulAgents[node.ObjectMeta.Name] = consulAgent
 		}
 	} else if c.cfg.Controller.RegisterMode == config.RegisterPodMode {
-		pods, err := c.clientset.Core().Pods("").List(v1.ListOptions{
+		pods, err := c.clientset.CoreV1().Pods("").List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.PodLabelSelector,
 		})
 		if err != nil {
@@ -114,7 +114,7 @@ func (c *Controller) Clean() error {
 		return err
 	}
 
-	endpoints, err := c.clientset.Core().Endpoints("").List(v1.ListOptions{})
+	endpoints, err := c.clientset.CoreV1().Endpoints("").List(v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (c *Controller) Sync() error {
 	}
 	glog.V(3).Infof("Added services: %#v", addedConsulServices)
 
-	endpoints, err := c.clientset.Core().Endpoints("").List(v1.ListOptions{})
+	endpoints, err := c.clientset.CoreV1().Endpoints("").List(v1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (c *Controller) Sync() error {
 
 // Watch watches events in K8S cluster
 func (c *Controller) Watch() {
-	watchlist := cache.NewListWatchFromClient(c.clientset.Core().RESTClient(), "endpoints", c.namespace,
+	watchlist := cache.NewListWatchFromClient(c.clientset.CoreV1().RESTClient(), "endpoints", c.namespace,
 		fields.Everything())
 	_, controller := cache.NewInformer(
 		watchlist,
@@ -380,7 +380,7 @@ func (c *Controller) eventUpdateFunc(oldObj interface{}, newObj interface{}) err
 }
 
 func (c *Controller) getPod(namespace string, podName string) (*v1.Pod, error) {
-	pod, err := c.clientset.Core().Pods(namespace).Get(podName)
+	pod, err := c.clientset.CoreV1().Pods(namespace).Get(podName)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/pods/controller.go
+++ b/controller/pods/controller.go
@@ -76,7 +76,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 		consulAgents[c.cfg.Controller.ConsulAddress] = consulAgent
 
 	} else if c.cfg.Controller.RegisterMode == config.RegisterNodeMode {
-		nodes, err := c.clientset.Core().Nodes().List(v1.ListOptions{
+		nodes, err := c.clientset.CoreV1().Nodes().List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.ConsulNodeSelector,
 		})
 		if err != nil {
@@ -89,7 +89,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 			consulAgents[node.ObjectMeta.Name] = consulAgent
 		}
 	} else if c.cfg.Controller.RegisterMode == config.RegisterPodMode {
-		pods, err := c.clientset.Core().Pods(c.namespace).List(v1.ListOptions{
+		pods, err := c.clientset.CoreV1().Pods(c.namespace).List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.PodLabelSelector,
 		})
 		if err != nil {
@@ -129,7 +129,7 @@ func (c *Controller) Clean() error {
 	}
 
 	// Make list of Kubernetes PODs
-	pods, err := c.clientset.Core().Pods(c.namespace).List(v1.ListOptions{
+	pods, err := c.clientset.CoreV1().Pods(c.namespace).List(v1.ListOptions{
 		LabelSelector: c.cfg.Controller.PodLabelSelector,
 	})
 	if err != nil {
@@ -196,7 +196,7 @@ func (c *Controller) Sync() error {
 	}
 	glog.V(3).Infof("Added services: %#v", addedConsulServices)
 
-	pods, err := c.clientset.Core().Pods(c.namespace).List(v1.ListOptions{
+	pods, err := c.clientset.CoreV1().Pods(c.namespace).List(v1.ListOptions{
 		LabelSelector: c.cfg.Controller.PodLabelSelector,
 	})
 	if err != nil {
@@ -229,7 +229,7 @@ func (c *Controller) Sync() error {
 
 // Watch watches events in K8S cluster
 func (c *Controller) Watch() {
-	watchlist := cache.NewListWatchFromClient(c.clientset.Core().RESTClient(), "pods", c.namespace,
+	watchlist := cache.NewListWatchFromClient(c.clientset.CoreV1().RESTClient(), "pods", c.namespace,
 		fields.Everything())
 	_, controller := cache.NewInformer(
 		watchlist,

--- a/controller/services/controller.go
+++ b/controller/services/controller.go
@@ -62,7 +62,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 		consulAgents[c.cfg.Controller.ConsulAddress] = consulAgent
 
 	} else if c.cfg.Controller.RegisterMode == config.RegisterNodeMode {
-		nodes, err := c.clientset.Core().Nodes().List(v1.ListOptions{
+		nodes, err := c.clientset.CoreV1().Nodes().List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.ConsulNodeSelector,
 		})
 		if err != nil {
@@ -75,7 +75,7 @@ func (c *Controller) cacheConsulAgent() (map[string]*consul.Adapter, error) {
 			consulAgents[node.ObjectMeta.Name] = consulAgent
 		}
 	} else if c.cfg.Controller.RegisterMode == config.RegisterPodMode {
-		pods, err := c.clientset.Core().Pods("").List(v1.ListOptions{
+		pods, err := c.clientset.CoreV1().Pods("").List(v1.ListOptions{
 			LabelSelector: c.cfg.Controller.PodLabelSelector,
 		})
 		if err != nil {
@@ -116,7 +116,7 @@ func (c *Controller) Clean() error {
 	}
 	glog.V(3).Infof("Added services: %#v", addedConsulServices)
 
-	allServices, err := c.clientset.Core().Services(c.namespace).List(v1.ListOptions{})
+	allServices, err := c.clientset.CoreV1().Services(c.namespace).List(v1.ListOptions{})
 	if err != nil {
 		c.mutex.Unlock()
 		return err
@@ -181,7 +181,7 @@ func (c *Controller) Sync() error {
 	}
 	glog.V(3).Infof("Added services: %#v", addedConsulServices)
 
-	allServices, err := c.clientset.Core().Services(c.namespace).List(v1.ListOptions{})
+	allServices, err := c.clientset.CoreV1().Services(c.namespace).List(v1.ListOptions{})
 	if err != nil {
 		c.mutex.Unlock()
 		return err
@@ -272,7 +272,7 @@ func (c *Controller) Watch() {
 }
 
 func (c *Controller) watchNodes() {
-	watchlist := cache.NewListWatchFromClient(c.clientset.Core().RESTClient(), "nodes", c.namespace,
+	watchlist := cache.NewListWatchFromClient(c.clientset.CoreV1().RESTClient(), "nodes", c.namespace,
 		fields.Everything())
 	_, controller := cache.NewInformer(
 		watchlist,
@@ -282,7 +282,7 @@ func (c *Controller) watchNodes() {
 			AddFunc: func(obj interface{}) {
 				c.mutex.Lock()
 				glog.Info("Add node.")
-				allServices, err := c.clientset.Core().Services(c.namespace).List(v1.ListOptions{})
+				allServices, err := c.clientset.CoreV1().Services(c.namespace).List(v1.ListOptions{})
 				if err != nil {
 					c.mutex.Unlock()
 				}
@@ -311,7 +311,7 @@ func (c *Controller) watchNodes() {
 }
 
 func (c *Controller) watchServices() {
-	watchlist := cache.NewListWatchFromClient(c.clientset.Core().RESTClient(), "services", c.namespace,
+	watchlist := cache.NewListWatchFromClient(c.clientset.CoreV1().RESTClient(), "services", c.namespace,
 		fields.Everything())
 	_, controller := cache.NewInformer(
 		watchlist,
@@ -486,7 +486,7 @@ func (c *Controller) eventAddFunc(obj interface{}) error {
 }
 
 func (c *Controller) getNodesIPs() ([]string, error) {
-	nodes, err := c.clientset.Core().Nodes().List(v1.ListOptions{})
+	nodes, err := c.clientset.CoreV1().Nodes().List(v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func (c *Controller) eventDeleteFunc(obj interface{}) error {
 }
 
 func (c *Controller) getPod(namespace string, podName string) (*v1.Pod, error) {
-	pod, err := c.clientset.Core().Pods(namespace).Get(podName)
+	pod, err := c.clientset.CoreV1().Pods(namespace).Get(podName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
howdy!

according to godoc, `Core()` is deprecated, in favor of `Core()` with an explicit version: https://godoc.org/k8s.io/client-go/kubernetes#Clientset.Core

This fixes all uses of `Core()` to call `CoreV1()` instead.