### PR TITLE
Skip adding Consul health check if exec liveness probe

### DIFF
--- a/controller/pods/controller.go
+++ b/controller/pods/controller.go
@@ -489,6 +489,10 @@ func (p *PodInfo) livenessProbeToConsulCheck(probe *v1.Probe) *consulapi.AgentSe
 		return check
 	}
 
+	if probe.Handler.Exec != nil {
+		return check
+	}
+
 	check.Status = "passing"
 	check.Interval = fmt.Sprintf("%ds", probe.PeriodSeconds)
 	check.Timeout = fmt.Sprintf("%ds", probe.TimeoutSeconds)


### PR DESCRIPTION
Fixes #32 

Changes:

1. Skip adding the Check for Consul if Exec type of livenessProbe
2. Added tests

Note:

Currently skipping. It is possible for Consul to exec into a docker container and then run the command. It is also possible to get the container ID from the Kubernetes Pod `Status`. This could be an alternative approach instead of skipping

