### PR TITLE
respect node selector in getNodeIPs

### DIFF
--- a/controller/services/controller.go
+++ b/controller/services/controller.go
@@ -495,7 +495,11 @@ func (c *Controller) eventAddFunc(obj interface{}) error {
 }
 
 func (c *Controller) getNodesIPs() ([]string, error) {
-	nodes, err := c.clientset.CoreV1().Nodes().List(v1.ListOptions{})
+	var listOptions v1.ListOptions
+	if c.cfg.Controller.RegisterMode == config.RegisterNodeMode {
+		listOptions.LabelSelector = c.cfg.Controller.ConsulNodeSelector
+	}
+	nodes, err := c.clientset.CoreV1().Nodes().List(listOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
 We recently changed ``register_source`` from pod to service and noticed that kube-consul-register would attempt to register services on nodes which didn't actually have the ``consul_node_selector``label set.
This commit fixes it.
