### PR TITLE
Update example API version

### DIFF
--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/nginx_multi_containers.yaml
+++ b/examples/nginx_multi_containers.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/rs.yaml
+++ b/examples/rs.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: kube-consul-register
@@ -20,3 +20,7 @@ spec:
         args:
         - -logtostderr=true
         - -configmap=default/kube-consul-register
+  selector:
+    matchLabels:
+      app: kube-consul-register
+


### PR DESCRIPTION
Since `extensions/v1beta1` was [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) quite a while ago, this updates the examples to match the new API. 