### PR TITLE
Fix: in-cluster is default false

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ kube-consul-register watches Kubernetes events and converts information about PO
   -consul-secret string
         name of the secret containing the consul token, e.g. default/consul. Key must be consul_token
   -in-cluster
-        use in-cluster config. Use always in case when controller is running on Kubernetes cluster (default true)
+        use in-cluster config. Use always in case when controller is running on Kubernetes cluster (default false)
   -kubeconfig string
         absolute path to the kubeconfig file (default "./kubeconfig")
   -log_backtrace_at value


### PR DESCRIPTION
Was wondering why it crashed:

```
I0803 14:33:00.734739       1 main.go:62] Using build: v0.1.9
F0803 14:33:00.734893       1 main.go:74] Error configuring the client: stat ./kubeconfig: no such file or directory
I0803 14:38:11.712914       1 main.go:62] Using build: v0.1.9
F0803 14:38:11.713063       1 main.go:74] Error configuring the client: stat ./kubeconfig: no such file or directory
```

... then figured out from reading the code here that it's the other way around:
https://github.com/tczekajlo/kube-consul-register/blob/d710950a4ed16306787ad88516ab63ed3aa0ed8a/main.go#L38