### PR TITLE
:fire: fix Sync() return error without unlock

### DIFF
--- a/controller/services/controller.go
+++ b/controller/services/controller.go
@@ -197,6 +197,7 @@ func (c *Controller) Sync() error {
 				if _, ok := addedConsulServices[serviceConsulID]; !ok {
 					err := c.eventAddFunc(&service)
 					if err != nil {
+						c.mutex.Unlock()
 						return err
 					}
 				}
@@ -204,6 +205,7 @@ func (c *Controller) Sync() error {
 		} else {
 			err := c.eventAddFunc(&service)
 			if err != nil {
+				c.mutex.Unlock()
 				return err
 			}
 		}


### PR DESCRIPTION
When Sync() return error in line 199 or 207, should unlock before return